### PR TITLE
Enable set 'Accept' and 'Content-Type' to headers

### DIFF
--- a/lib/capybara/typhoeus/browser.rb
+++ b/lib/capybara/typhoeus/browser.rb
@@ -58,7 +58,7 @@ class Capybara::Typhoeus::Browser < Capybara::RackTest::Browser
       opts = driver.with_options
       opts[:method] = method
       opts[:headers] = driver.with_headers.merge(
-        headers.merge("Content-Type" => driver.as, "Accept" => driver.as)
+        {"Content-Type" => driver.as, "Accept" => driver.as}.merge headers
       )
       referer = opts[:headers].delete "HTTP_REFERER"
       opts[:headers]["Referer"] = referer if referer


### PR DESCRIPTION
@JonathanTron In one of my feature test, I want to set the "Accept" different with "Content-Type" in headers, so I changed the code. Please review it, thanks!