### PR TITLE
allow set params_encoding for the option in ethon

### DIFF
--- a/lib/capybara/typhoeus/browser.rb
+++ b/lib/capybara/typhoeus/browser.rb
@@ -87,6 +87,7 @@ class Capybara::Typhoeus::Browser < Capybara::RackTest::Browser
         opts[:userpwd] = "#{driver.login}:#{driver.password}"
       end
       opts[:params] = driver.with_params.merge(params)
+      opts[:params_encoding] = driver.params_encoding
       if request_body
         opts[:body] = request_body
         @request_body = nil

--- a/lib/capybara/typhoeus/driver.rb
+++ b/lib/capybara/typhoeus/driver.rb
@@ -1,10 +1,11 @@
 class Capybara::Typhoeus::Driver < Capybara::RackTest::Driver
 
   attr_writer :as, :with_headers, :with_params, :with_options
-  attr_reader :login, :password
+  attr_reader :login, :password, :params_encoding
 
   def initialize(app, options = {})
     raise ArgumentError, "typhoeus requires a rack application, but none was given" unless app
+    @params_encoding = options[:params_encoding]
     super app, {timeout: 3, forbid_reuse: true}.merge(options)
   end
 


### PR DESCRIPTION
Without the option `params_encoding`, we can't send the params and encode an array correctly, for example if we send a get request like this:
```
page.get "/api/employees", {id: [1,2,3]}
```
Then the url is encoded as `/api/employees?id[0]=1&id[1]=2&id[2]=3`, which we expect it should be `/api/employees?id[]=1&id[]=2&id[]=3` in the rails standard format. 

I debugged into the code and finally got it's encoded in `ethon`, see the code from here https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L120-L125
and this method https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L101-L105, what we need to do is set the `params_encoding` to `:rack`.

If you want to know more detail about this issue, please see the MR: https://github.com/typhoeus/ethon/pull/104

So that means `capybara-typhoeus` should accept the `params_encoding` and pass it into the `ethon`. 

I'm not sure if my change in this MR is the best way to do it, please let me know if there has any advice.